### PR TITLE
Ajout de deux remplacements

### DIFF
--- a/js/correct.js
+++ b/js/correct.js
@@ -4,4 +4,6 @@ while(textNode=walk.nextNode()) {
     .replace(/Emmanuel Macron/gi, 'Manu')
     .replace(/le Président de la République/gi, 'Manu')
     .replace(/Monsieur le Président/gi, 'Manu')
+    .replace(/M\. Macron/gi, 'Manu')
+    .replace(/Président Macron/gi, 'Manu')
 }


### PR DESCRIPTION
Suite à la lecture d'un article de test à cette URL : https://www.lemonde.fr/politique/article/2018/06/19/le-president-le-resistant-et-le-trublion_5317460_823448.html

On se rend compte qu'il manque 2 regexp qui peuvent être utiles à un meilleur rendu final du contenu