### PR TITLE
Creation d'une seule RegEx principale pour 'Manu', extension pour couple

### DIFF
--- a/js/correct.js
+++ b/js/correct.js
@@ -1,19 +1,22 @@
 var textNode,
   walk = document.createTreeWalker(document, NodeFilter.SHOW_TEXT, null, false)
-const rExpManu = new RegExp('emmanuelmacron|' +
-    '(?:\bm.?|monsieur|[eé]mmanuel(?: jean-michel fr[eé]d[eé]ric)?) macron|' +
-    '(?:\bm.? |monsieur )?le pr[ée]sident' +
+const sPres = 'pr[ée]sident' +
         '(?: de la r[ée]publique(?: fran[çc]aise)?|' +
-        ' macron| fran[çc]ais)?(?! [(]| de (?!la|f))|' +
+        ' (?:[eé]mmanuel )?macron| fran[çc]ais)?(?! [(]| de (?!la|f))'
+const rExpPres = new RegExp('du(?= ' + sPres + ')', 'gi')
+const rExpManu = new RegExp('emmanuel(?: |)macron|' +
+    '(?:\bm.?|monsieur|[eé]mmanuel(?: jean-michel fr[eé]d[eé]ric)?) macron|' +
+    '(?:\bm.? |monsieur )?le ' + sPres + '|' +
     'the (?:president of france|french president)'
         , 'gi')
 
 while ((textNode = walk.nextNode())) {
   textNode.nodeValue = textNode.nodeValue
-    .replace(/((?:d|qu))['’][eé]mmanuel macron/gi, '$1e Manu')
-    .replace(/((?:d|qu)e) macron/gi, '$1 Manu')
+    .replace(/(\b(?:d|qu))['’](?=[eé]mmanuel macron)/gi, '$1e ')
+    .replace(/(\b(?:d|qu)e) macron/gi, '$1 Manu')
     .replace(/[eé]mmanuel et brigitte macron/gi, 'Manu et Brigitte')
     .replace(/brigitte et [eé]mmanuel macron/gi, 'Brigitte et Manu')
     .replace(/couple macron/gi, 'couple à Manu')
+    .replace(rExpPres, 'de le')
     .replace(rExpManu, 'Manu')
 }

--- a/js/correct.js
+++ b/js/correct.js
@@ -3,11 +3,11 @@ var textNode,
 const sPres = 'pr[ée]sident' +
         '(?:\\s+de\\s+la\\s+r[ée]publique(?:\\s+fran[çc]aise)?|' +
         '\\s+(?:[eé]mmanuel\\s+)?macron|\\s+fran[çc]ais)?(?!\\s+[(]|\\s+de\\s+(?!la|f))'
-const rExpPres = new RegExp('du(?=\\s+' + sPres + ')', 'gi')
-const rExpManu = new RegExp('emmanuel(?:\\s+|)macron|' +
+const rExpDuPres = new RegExp('du(?=\\s+' + sPres + ')', 'gi')
+const rExpManu = new RegExp('[eé]mmanuel\\s*macron|' +
     '(?:\\bm.?|monsieur|[eé]mmanuel(?:\\s+jean-michel\\s+fr[eé]d[eé]ric)?)\\s+macron|' +
     '(?:\\bm.?\\s+|monsieur\\s+)?le\\s+' + sPres + '|' +
-    'the\\s+(?:president\\s+of\\s+france|french\\spresident)'
+    'the\\s+(?:president\\s+of\\s+france|french\\s+president)'
         , 'gi')
 
 while ((textNode = walk.nextNode())) {
@@ -17,6 +17,6 @@ while ((textNode = walk.nextNode())) {
     .replace(/[eé]mmanuel\s+et\s+brigitte macron/gi, 'Manu et Brigitte')
     .replace(/brigitte\s+et\s+[eé]mmanuel\s+macron/gi, 'Brigitte et Manu')
     .replace(/couple\s+macron/gi, 'couple à Manu')
-    .replace(rExpPres, 'de le')
+    .replace(rExpDuPres, 'de le')
     .replace(rExpManu, 'Manu')
 }

--- a/js/correct.js
+++ b/js/correct.js
@@ -1,16 +1,18 @@
-var textNode, walk=document.createTreeWalker(document,NodeFilter.SHOW_TEXT,null,false);
-const rExp = new RegExp('Emmanuel Macron|'+
-	'EmmanuelMacron|'+
-	'M. le Président de la République|'+ // Keep the dot in case of "Mr" or "M."
-	'le Président de la République|'+ // Put this one after, so that the one above matches first
-	'Monsieur le Président de la République|'+
-	'Monsieur le Président|'+
-	'Président de la République française|'+
-	'Président de la République|' +
-	'Le Président Macron|' +
-	'Emmanuel Jean-Michel Frédéric Macron|' +
-	'M. Macron', 'gi');
+var textNode,
+  walk = document.createTreeWalker(document, NodeFilter.SHOW_TEXT, null, false)
+const rExpManu = new RegExp('emmanuelmacron|' +
+    '(?:m.?|monsieur|[eé]mmanuel(?: jean-michel fr[eé]d[eé]ric)?) macron|' +
+    '(?:m.? |monsieur )?le pr[ée]sident(?: de la r[ée]publique' +
+        '(?: fran[çc]aise| macron| fran[çc]ais)?)?|' +
+    'the (?:president of france|french president)|' +
+    'macron' /* à garder en dernière regex */
+        , 'gi')
 
-while(textNode=walk.nextNode()) {
-    textNode.nodeValue = textNode.nodeValue.replace(rExp, 'Manu');
+while ((textNode = walk.nextNode())) {
+  textNode.nodeValue = textNode.nodeValue
+    .replace(/d['’][eé]mmanuel macron/gi, 'de Manu')
+    .replace(/[eé]mmanuel et brigitte macron/gi, 'Manu et Brigitte')
+    .replace(/brigitte et [eé]mmanuel macron/gi, 'Brigitte et Manu')
+    .replace(/couple macron/gi, 'couple à Manu')
+    .replace(rExpManu, 'Manu')
 }

--- a/js/correct.js
+++ b/js/correct.js
@@ -1,22 +1,22 @@
 var textNode,
   walk = document.createTreeWalker(document, NodeFilter.SHOW_TEXT, null, false)
 const sPres = 'pr[ée]sident' +
-        '(?: de la r[ée]publique(?: fran[çc]aise)?|' +
-        ' (?:[eé]mmanuel )?macron| fran[çc]ais)?(?! [(]| de (?!la|f))'
-const rExpPres = new RegExp('du(?= ' + sPres + ')', 'gi')
-const rExpManu = new RegExp('emmanuel(?: |)macron|' +
-    '(?:\bm.?|monsieur|[eé]mmanuel(?: jean-michel fr[eé]d[eé]ric)?) macron|' +
-    '(?:\bm.? |monsieur )?le ' + sPres + '|' +
-    'the (?:president of france|french president)'
+        '(?:\\s+de\\s+la\\s+r[ée]publique(?:\\s+fran[çc]aise)?|' +
+        '\\s+(?:[eé]mmanuel\\s+)?macron|\\s+fran[çc]ais)?(?!\\s+[(]|\\s+de\\s+(?!la|f))'
+const rExpPres = new RegExp('du(?=\\s+' + sPres + ')', 'gi')
+const rExpManu = new RegExp('emmanuel(?:\\s+|)macron|' +
+    '(?:\\bm.?|monsieur|[eé]mmanuel(?:\\s+jean-michel\\s+fr[eé]d[eé]ric)?)\\s+macron|' +
+    '(?:\\bm.?\\s+|monsieur\\s+)?le\\s+' + sPres + '|' +
+    'the\\s+(?:president\\s+of\\s+france|french\\spresident)'
         , 'gi')
 
 while ((textNode = walk.nextNode())) {
   textNode.nodeValue = textNode.nodeValue
     .replace(/(\b(?:d|qu))['’](?=[eé]mmanuel macron)/gi, '$1e ')
-    .replace(/(\b(?:d|qu)e) macron/gi, '$1 Manu')
-    .replace(/[eé]mmanuel et brigitte macron/gi, 'Manu et Brigitte')
-    .replace(/brigitte et [eé]mmanuel macron/gi, 'Brigitte et Manu')
-    .replace(/couple macron/gi, 'couple à Manu')
+    .replace(/(\b(?:d|qu)e)\s+macron/gi, '$1 Manu')
+    .replace(/[eé]mmanuel\s+et\s+brigitte macron/gi, 'Manu et Brigitte')
+    .replace(/brigitte\s+et\s+[eé]mmanuel\s+macron/gi, 'Brigitte et Manu')
+    .replace(/couple\s+macron/gi, 'couple à Manu')
     .replace(rExpPres, 'de le')
     .replace(rExpManu, 'Manu')
 }

--- a/js/correct.js
+++ b/js/correct.js
@@ -1,16 +1,17 @@
 var textNode,
   walk = document.createTreeWalker(document, NodeFilter.SHOW_TEXT, null, false)
 const rExpManu = new RegExp('emmanuelmacron|' +
-    '(?:m.?|monsieur|[eé]mmanuel(?: jean-michel fr[eé]d[eé]ric)?) macron|' +
-    '(?:m.? |monsieur )?le pr[ée]sident(?: de la r[ée]publique' +
-        '(?: fran[çc]aise| macron| fran[çc]ais)?)?|' +
-    'the (?:president of france|french president)|' +
-    'macron' /* à garder en dernière regex */
+    '(?:\bm.?|monsieur|[eé]mmanuel(?: jean-michel fr[eé]d[eé]ric)?) macron|' +
+    '(?:\bm.? |monsieur )?le pr[ée]sident' +
+        '(?: de la r[ée]publique(?: fran[çc]aise)?|' +
+        ' macron| fran[çc]ais)?(?! [(]| de (?!la|f))|' +
+    'the (?:president of france|french president)'
         , 'gi')
 
 while ((textNode = walk.nextNode())) {
   textNode.nodeValue = textNode.nodeValue
-    .replace(/d['’][eé]mmanuel macron/gi, 'de Manu')
+    .replace(/((?:d|qu))['’][eé]mmanuel macron/gi, '$1e Manu')
+    .replace(/((?:d|qu)e) macron/gi, '$1 Manu')
     .replace(/[eé]mmanuel et brigitte macron/gi, 'Manu et Brigitte')
     .replace(/brigitte et [eé]mmanuel macron/gi, 'Brigitte et Manu')
     .replace(/couple macron/gi, 'couple à Manu')


### PR DESCRIPTION
Le remplacement par le mot 'Manu' se fait pour la majorité des
références au président de la république française (ou toutes les
formules raccourcies aussi), avec ou sans accent, avec ou sans
cédille. Prise en compte des versions raccourcies de "monsieur" aussi.

Ajout de deux formules anglophones. Ça pourrait être enrichi
ultérieurement avec d'autre langues.

Prise en compte de l'apostrophe (à la place de la simple quote qui est
toujours présente, mais sans doute un peu inutile ici).

Prise en compte de l'issue #1 avec la prise en compte du couple. Ici
double référence, en disant bien "couple *à*" en référence au tollé de
la "fête à macron" ; on conserve la notion de couple plutôt que de
remplacer par juste "Manu" qui exclu Brigitte (qui n'a rien demandé, la
pauvre), et si on remplaçait par "Manu et Brigitte", il aurait fallu
accorder les verbes en conséquence, et c'est pas le but ici.