### PR TITLE
Creation d'une seule RegEx principale pour 'Manu'

### DIFF
--- a/js/correct.js
+++ b/js/correct.js
@@ -1,18 +1,69 @@
-const textNode, walk = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT,null,false);
-const rExp = new RegExp('Emmanuel Macron|'+
-	'EmmanuelMacron|'+
-	'M[\.r] le Président de la République|'+ // Keep the dot in case of "Mr" or "M."
-	'le Président de la République|'+ // Put this one after, so that the one above matches first
-	'Monsieur le Président de la République|'+
-	'Monsieur le Président|'+
-	'Président de la République française|'+
-	'Président de la République|' +
-	'Le Président Macron|' +
-	'Emmanuel Jean-Michel Frédéric Macron|' +
-	'M[\.r] Macron', 'gi');
+function textReplaceManu(str) {
+    /* Here we build a string to detect the "*du* président ..." formula */
+    const strPres = 'pr[ée]sident de la r[ée]publique|'+
+        'pr[ée]sident de la r[ée]publique fran[cç]aise|'+
+        'pr[ée]sident fran[cç]ais|'+
+        'pr[ée]sident emmanuel macron|'+
+        'pr[ée]sident macron'
+    /* This is just "catch *DU* if followed by "président etc..." formula */
+    const rExpDuPres = new RegExp('du(?=\\s+' + strPres.replace(/ /g, '\\s+') + ')', 'gi')
+    /* Build replacement regex */
+    const strManu = 'EmmanuelMacron|'+
+		'M[\\.r] le Pr[eé]sident de la R[eé]publique fran[cç]aise|'+ // Keep the dot in case of "Mr" or "M."
+		'M[\\.r] le Pr[eé]sident de la R[eé]publique|'+
+		'M[\\.r] le Pr[eé]sident fran[cç]ais|'+
+		'M[\\.r] le Pr[eé]sident emmanuel macron|'+
+		'M[\\.r] le Pr[eé]sident macron|'+
+		'M[\\.r] le Pr[eé]sident|'+
+		'Monsieur le Pr[eé]sident de la R[eé]publique fran[cç]aise|'+
+		'Monsieur le Pr[eé]sident de la R[eé]publique|'+
+		'Monsieur le Pr[eé]sident fran[cç]ais|'+
+		'Monsieur le Pr[eé]sident emmanuel macron|'+
+		'Monsieur le Pr[eé]sident macron|'+
+		'Monsieur le Pr[eé]sident|'+
+		'le Pr[eé]sident de la R[eé]publique fran[cç]aise|'+ // Put this one after, so that the one above matches first
+		'le Pr[eé]sident de la R[eé]publique|'+
+		'Le Pr[eé]sident fran[cç]ais|'+
+		'Le Pr[eé]sident emmanuel Macron|'+
+		'Le Pr[eé]sident Macron|'+
+		'Pr[eé]sident de la R[eé]publique fran[cç]aise|'+
+		'Pr[eé]sident de la R[eé]publique|'+
+		'Emmanuel Macron|'+
+		'Emmanuel Jean-Michel Fr[eé]d[eé]ric Macron|'+
+		'M[\\.r] emmanuel Macron|'+
+		'M[\\.r] Macron|'+
+		'french president|'+
+		'president of france'
+    /* before creating RegEx, change all ' ' in the string by '\s+' to it can detect all double spaces,
+     * or unbreakable spaces in the text as well.
+     */
+    const rExpManu = new RegExp(strManu.replace(/ /g,'\\s+'),  'gi');
 
-while(textNode=walk.nextNode()) {
-    textNode.nodeValue = textNode.nodeValue.replace(rExp, 'Manu');
+	/* Apply replacement in the text */
+	/* 1) replace "d'Emmanuel Macron" with "de Manu". Same with "qu'Emmanuel macron"
+	 * 2) replace "de Macron" or "que Macron" with "de Manu" or "que Manu" respectively
+     * 3) replace "Emmanuel et Brigitte Macron" with "Manu et Brigitte'
+     * 4) same as 3), but with Brigitte first
+     * 5) replace "couple macron" and "couple présidentiel" with "couple à Manu"
+     * 6) replace "du président etc" with "de le prédisent etc...", in order to have
+     *      "le président etc..." replace with "Manu" next
+     * 7) replace all references to "président de la republique etc..." by "Manu"
+	 */
+	return str.replace(/(\b(?:d|qu))['’][eé]mmanuel macron/gi, '$1e Manu')
+		.replace(/(\b(?:d|qu)e) macron/gi, '$1 Manu')
+		.replace(/[eé]mmanuel et brigitte macron/gi, 'Manu et Brigitte')
+		.replace(/brigitte et [eé]mmanuel macron/gi, 'Brigitte et Manu')
+		.replace(/couple macron|couple pr[eé]sidentiel/gi, 'couple à Manu')
+		.replace(rExpDuPres, 'de le')
+		.replace(rExpManu, 'Manu')
 }
 
-document.title = document.title.replace(rExp, 'Manu');
+var textNode
+const walk = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT,null,false);
+while ((textNode = walk.nextNode())) {
+    /* Apply all the replacement to each text node content */
+    textNode.nodeValue = textReplaceManu(textNode.nodeValue)
+}
+
+/* Apply all the same replacement as for the text. */
+document.title = textReplaceManu(document.title)

--- a/js/correct.js
+++ b/js/correct.js
@@ -6,7 +6,10 @@ function textReplaceManu(str) {
         'pr[ée]sident emmanuel macron|'+
         'pr[ée]sident macron'
     /* This is just "catch *DU* if followed by "président etc..." formula */
-    const rExpDuPres = new RegExp('du(?=\\s+' + strPres.replace(/ /g, '\\s+') + ')', 'gi')
+    const rExpDuPres = new RegExp('\\bdu(?=\\s+' + strPres.replace(/ /g, '\\s+') + ')', 'gi')
+    /* This is just "catch *AU* if followed by "président etc..." formula. Notice the "\\b" at the
+     * begining. It ensures "au" is a stand alone word. Do not remove it. */
+    const rExpAuPres = new RegExp('\\bau(?=\\s+' + strPres.replace(/ /g, '\\s+') + ')', 'gi')
     /* Build replacement regex */
     const strManu = 'EmmanuelMacron|'+
 		'M[\\.r] le Pr[eé]sident de la R[eé]publique fran[cç]aise|'+ // Keep the dot in case of "Mr" or "M."
@@ -39,15 +42,17 @@ function textReplaceManu(str) {
      */
     const rExpManu = new RegExp(strManu.replace(/ /g,'\\s+'),  'gi');
 
-	/* Apply replacement in the text */
+	/* Apply replacement in text */
 	/* 1) replace "d'Emmanuel Macron" with "de Manu". Same with "qu'Emmanuel macron"
 	 * 2) replace "de Macron" or "que Macron" with "de Manu" or "que Manu" respectively
      * 3) replace "Emmanuel et Brigitte Macron" with "Manu et Brigitte'
      * 4) same as 3), but with Brigitte first
      * 5) replace "couple macron" and "couple présidentiel" with "couple à Manu"
      * 6) replace "du président etc" with "de le prédisent etc...", in order to have
-     *      "le président etc..." replace with "Manu" next
-     * 7) replace all references to "président de la republique etc..." by "Manu"
+     *      "le président etc..." replace with "Manu" later
+     * 6) replace "au président etc" with "à le prédisent etc...", in order to have
+     *      "le président etc..." replace with "Manu" later
+     * 8) replace all references to "président de la republique etc..." by "Manu"
 	 */
 	return str.replace(/(\b(?:d|qu))['’][eé]mmanuel macron/gi, '$1e Manu')
 		.replace(/(\b(?:d|qu)e) macron/gi, '$1 Manu')
@@ -55,6 +60,7 @@ function textReplaceManu(str) {
 		.replace(/brigitte et [eé]mmanuel macron/gi, 'Brigitte et Manu')
 		.replace(/couple macron|couple pr[eé]sidentiel/gi, 'couple à Manu')
 		.replace(rExpDuPres, 'de le')
+		.replace(rExpAuPres, 'à le')
 		.replace(rExpManu, 'Manu')
 }
 


### PR DESCRIPTION
Cette PR remplace la PR #8 avec une version plus lisible, et plus simple à comprendre pour qui n'est pas habitué aux Regex. Il ne reste quelques unes, il reste deux trois subtilités, mais tout est commenté :)

Le remplacement par le mot 'Manu' se fait pour la majorité des
références au président de la république française (ou toutes les
formules raccourcies aussi), avec ou sans accent, avec ou sans
cédille. Prise en compte des versions raccourcies de "monsieur" aussi.

Ajout de deux formules anglophones. Ça pourrait être enrichi
ultérieurement avec d'autre langues.

Prise en compte de l'apostrophe (à la place de la simple quote qui est
toujours présente, mais sans doute un peu inutile ici).

Prise en compte de l'issue qui existait qui demandait la prise en compte du couple. Ici
double référence, en disant bien "couple *à*" en référence au tollé de
la "fête à macron" ; on conserve la notion de couple plutôt que de
remplacer par juste "Manu" qui exclu Brigitte (qui n'a rien demandé, la
pauvre), et si on remplaçait par "Manu et Brigitte", il aurait fallu
accorder les verbes en conséquence, et c'est pas le but ici.

Ne pas remplacer lors d'un président de parti/région/asso

En partie en raison de la page indiquée dans l'issue#2 où était indiqué
"le président (LR) de ...".

Prise en compte un peu plus propre des apostrophes pour d' et qu'.
Corrige l'issue #21 et #23 .

Corrige l'issue #6.

retirer la dernière condition de changement sur juste "Macron" pour
eviter que "Brigitte Macron" ne devienne "Brigitte Manu". Ça manque de
negative look-behind pour faire ça bien je crois...

La sous string extraite permet de réutiliser la string pour la seconde
regexp utile pour détecter les formes telles que "du président" tel que
mentionné dans la PR #12

Ajout de check de bornes de mots (notamment important pour les "de"
"que" ou "du".